### PR TITLE
[SPARK-18004][SQL] Make sure the date or timestamp related predicate can be pushed down to Oracle correctly

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -149,4 +149,49 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
     assert(values.getDate(9).equals(dateVal))
     assert(values.getTimestamp(10).equals(timestampVal))
   }
+
+  test("SPARK-18004: Make sure date or timestamp related predicate is pushed down correctly") {
+    val props = new Properties()
+    props.put("oracle.jdbc.mapDateToTimestamp", "false")
+
+    val schema = StructType(Seq(
+      StructField("date_type", DateType, true),
+      StructField("timestamp_type", TimestampType, true)
+    ))
+
+    val tableName = "test_date_timestamp_pushdown"
+    val dateVal = Date.valueOf("2017-06-22")
+    val timestampVal = Timestamp.valueOf("2017-06-22 21:30:07")
+
+    val data = spark.sparkContext.parallelize(Seq(
+      Row(dateVal, timestampVal)
+    ))
+
+    val dfWrite = spark.createDataFrame(data, schema)
+    dfWrite.write.jdbc(jdbcUrl, tableName, props)
+
+    val dfRead = spark.read.jdbc(jdbcUrl, tableName, props)
+
+    val millis = System.currentTimeMillis()
+    val dt = new java.sql.Date(millis)
+    val ts = new java.sql.Timestamp(millis)
+
+    // Query Oracle table with date and timestamp predicates
+    // which should be pushed down to Oracle.
+    val df = dfRead.filter(dfRead.col("date_type").lt(dt))
+      .filter(dfRead.col("timestamp_type").lt(ts))
+
+    val metadata = df.queryExecution.sparkPlan.metadata
+    // The "PushedFilters" part should be exist in Datafrome's
+    // physical plan and the existence of right literals in
+    // "PushedFilters" is used to prove that the predicates
+    // pushing down have been effective.
+    assert(metadata.get("PushedFilters").ne(None))
+    assert(metadata("PushedFilters").contains(dt.toString))
+    assert(metadata("PushedFilters").contains(ts.toString))
+
+    val row = df.collect()(0)
+    assert(row.getDate(0).equals(dateVal))
+    assert(row.getTimestamp(1).equals(timestampVal))
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -51,8 +51,8 @@ private case object OracleDialect extends JdbcDialect {
         case _ => None
       }
     } else if (sqlType == Types.TIMESTAMP && typeName.toLowerCase() == "date") {
-      // Timestamp and date type are same data types in the versio of oracle jdbc after 10g.
-      // So we should differentiate date type from timestamp type.
+      // Timestamp and date type are the same data type in the versions of oracle
+      // jdbc after 10g. So we should differentiate date type from timestamp type.
       Option(DateType)
     } else {
       None
@@ -74,7 +74,7 @@ private case object OracleDialect extends JdbcDialect {
   }
 
   override def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
-    // Set time format before query
+    // Set general time format before query
     val stmt = connection.createStatement()
     stmt.execute("alter session set NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF'")
     stmt.execute("alter session set NLS_DATE_FORMAT = 'YYYY-MM-DD'")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -731,6 +731,8 @@ class JDBCSuite extends SparkFunSuite
       Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
     assert(oracleDialect.getCatalystType(java.sql.Types.NUMERIC, "numeric", 0, null) ==
       Some(DecimalType(DecimalType.MAX_PRECISION, 10)))
+    assert(oracleDialect.getCatalystType(java.sql.Types.TIMESTAMP, "date", 0, null) ==
+      Some(DateType))
   }
 
   test("table exists query by jdbc dialect") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Override beforeFetch method in OracleDialect to finish the following two things:
    -  Set Oracle's NLS_TIMESTAMP_FORMAT to "YYYY-MM-DD HH24:MI:SS.FF" to match java.sql.Timestamp format.
    -  Set Oracle's NLS_DATE_FORMAT to "YYYY-MM-DD" to match java.sql.Date format.


2. Timestamp and Date type are the same data type in the versions of oracle jdbc after 10g. So we should differentiate Date type from Timestamp type to make sure the Date-related predicates can be pushed down to Oracle correctly. The related work is done in the getCatalystType method of the OracleDialect object.

## How was this patch tested?

An integration test has been added and a existing unit test has been modified.